### PR TITLE
HW10/remove_lowercase: truncate output instead of input

### DIFF
--- a/HW10/library.py
+++ b/HW10/library.py
@@ -22,7 +22,7 @@ def remove_lowercase(input_string: str) -> str:
     :return: truncated and filtered string
     :rtype: str
     """
-    ret = ''.join(filter(lambda c: c.isupper(), input_string[:25]))
+    ret = ''.join(filter(lambda c: c.isupper(), input_string))[:25]
     return ret
 
 

--- a/HW10/test_library.py
+++ b/HW10/test_library.py
@@ -7,7 +7,8 @@ testcases_remove_lowercase_positive = [
     ('abc', ''),
     ('ABC', 'ABC'),
     ('', ''),
-    ('X' * 50, 'X' * 25)
+    ('X' * 50, 'X' * 25),
+    ('Qw' * 100, 'Q' * 25)
 ]
 
 


### PR DESCRIPTION
>  ret=''.join(filter(lambdac: c.isupper(), input_string[:25]))
ти обрізала вхідний результат, а задумка була обрізати вихідні дані